### PR TITLE
Eliminate dependency on quiver_hashcode

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,9 +9,8 @@ environment:
 
 dependencies:
   meta: ^1.1.7
-  quiver_hashcode: ^2.0.0
   grizzly_range: ^2.0.4
 
 dev_dependencies:
-  test:
-  pedantic:
+  test: ^1.0.0
+  pedantic: ^1.11.0


### PR DESCRIPTION
Development on the quiver_* subpackages has been discontinued in favour
of the main quiver package at https://github.com/~/quiver-dart. The
code itself is identical, but is more actively maintained.

Since this package doesn't use any of the functions defined in this package,
I've simply deleted the dependency.

I've also fixed up the test/pedantic dependencies.